### PR TITLE
feat: support plugin dependencies replace directive

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -244,16 +244,21 @@ func (b *Builder) goGetMod(repo, hash string) error {
 	return nil
 }
 
-func (b *Builder) getDepsReplace(repl string) (result []*Entry) {
+func (b *Builder) getDepsReplace(repl string) []*Entry {
 	b.log.Info("[REPLACING DEPENDENCIES]", zap.String("dependency", repl))
 	modFile, err := os.ReadFile(path.Join(repl, goModStr))
 	if err != nil {
-		return
+		return []*Entry{}
 	}
 
+	result := []*Entry{}
 	replaces := replaceRegexp.FindAllStringSubmatch(string(modFile), -1)
-	for _, replace := range replaces {
-		split := strings.Split(strings.TrimSpace(replace[0]), " => ")
+	for i := 0; i < len(replaces); i++ {
+		split := strings.Split(strings.TrimSpace(replaces[i][0]), " => ")
+		if len(split) != 2 {
+			continue
+		}
+
 		moduleName := split[0]
 		moduleReplace := split[1]
 
@@ -267,7 +272,7 @@ func (b *Builder) getDepsReplace(repl string) (result []*Entry) {
 		})
 	}
 
-	return
+	return result
 }
 
 func moveFile(from, to string) error {

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -248,7 +248,7 @@ func (b *Builder) getDepsReplace(repl string) []*Entry {
 	b.log.Info("[REPLACING DEPENDENCIES]", zap.String("dependency", repl))
 	modFile, err := os.ReadFile(path.Join(repl, goModStr))
 	if err != nil {
-		return []*Entry{}
+		return nil
 	}
 
 	result := []*Entry{}
@@ -256,6 +256,7 @@ func (b *Builder) getDepsReplace(repl string) []*Entry {
 	for i := 0; i < len(replaces); i++ {
 		split := strings.Split(strings.TrimSpace(replaces[i][0]), " => ")
 		if len(split) != 2 {
+			b.log.Error("Error while trying to split", zap.String("replace", replaces[i][0]))
 			continue
 		}
 

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -251,7 +251,8 @@ func (b *Builder) getDepsReplace(repl string) []*Entry {
 		return nil
 	}
 
-	result := []*Entry{}
+	//nolint:prealloc
+	var result []*Entry
 	replaces := replaceRegexp.FindAllStringSubmatch(string(modFile), -1)
 	for i := 0; i < len(replaces); i++ {
 		split := strings.Split(strings.TrimSpace(replaces[i][0]), " => ")

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -52,13 +52,26 @@ replace (
 	github.com/dummy/package_two => /tmp/dummy_two
 )
 `
+	replaceGoModMultipleRemote = `module go.dev/my/module
+go 1.18
+
+require (
+	github.com/fatih/color v1.13.0
+)
+
+replace (
+	github.com/dummy/package_one => https://github.com/my/package_one
+	github.com/dummy/package_two => https://github.com/my/package_two
+)
+`
 )
 
 var associated = map[string][]byte{
-	"dummy_one_relative":      []byte(replaceGoModOneRelative),
-	"dummy_one_absolute":      []byte(replaceGoModOneAbsolute),
-	"dummy_multiple_relative": []byte(replaceGoModMultipleRelative),
-	"dummy_multiple_absolute": []byte(replaceGoModMultipleAbsolute),
+	"dummy_one_relative":             []byte(replaceGoModOneRelative),
+	"dummy_one_absolute":             []byte(replaceGoModOneAbsolute),
+	"dummy_multiple_relative":        []byte(replaceGoModMultipleRelative),
+	"dummy_multiple_absolute":        []byte(replaceGoModMultipleAbsolute),
+	"dummy_multiple_absolute_remote": []byte(replaceGoModMultipleRemote),
 }
 
 func Test_Builder_getDepsReplace(t *testing.T) {
@@ -84,6 +97,11 @@ func Test_Builder_getDepsReplace(t *testing.T) {
 			Version:    "master",
 			ModuleName: "dummy_multiple_absolute",
 			Replace:    "/tmp/dummy_multiple_absolute",
+		},
+		{
+			Version:    "master",
+			ModuleName: "dummy_multiple_absolute_remote",
+			Replace:    "/tmp/dummy_multiple_absolute_remote",
 		},
 	}
 
@@ -134,5 +152,16 @@ func Test_Builder_getDepsReplace(t *testing.T) {
 	}
 	if toReplace[0].Module != "github.com/dummy/package" || toReplace[0].Replace != "/tmp/dummy_one_relative/something" {
 		t.Error("The module to replace must be github.com/dummy/package with the replacer /tmp/dummy_one_relative/something")
+	}
+
+	toReplace = b.getDepsReplace("/tmp/dummy_multiple_absolute_remote")
+	if len(toReplace) != 2 {
+		t.Error("/tmp/dummy_multiple_relative must have 2 elements to replace")
+	}
+	if toReplace[0].Module != "github.com/dummy/package_one" || toReplace[0].Replace != "https://github.com/my/package_one" {
+		t.Error("The first module to replace must be github.com/dummy/package_one with the replacer https://github.com/my/package_one")
+	}
+	if toReplace[1].Module != "github.com/dummy/package_two" || toReplace[1].Replace != "https://github.com/my/package_two" {
+		t.Error("The first module to replace must be github.com/dummy/package_two with the replacer https://github.com/my/package_two")
 	}
 }

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -1,0 +1,138 @@
+package builder
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/roadrunner-server/velox/common"
+	"go.uber.org/zap"
+)
+
+const (
+	replaceGoModOneRelative = `module go.dev/my/module
+go 1.18
+
+require (
+	github.com/fatih/color v1.13.0
+)
+
+replace github.com/dummy/package => ./something
+`
+	replaceGoModOneAbsolute = `module go.dev/my/module
+go 1.18
+
+require (
+	github.com/fatih/color v1.13.0
+)
+
+replace github.com/dummy/package => /tmp/dummy
+`
+	replaceGoModMultipleRelative = `module go.dev/my/module
+go 1.18
+
+require (
+	github.com/fatih/color v1.13.0
+)
+
+replace (
+	github.com/dummy/package => ./something
+	github.com/dummy/another => ../../another
+)
+`
+	replaceGoModMultipleAbsolute = `module go.dev/my/module
+go 1.18
+
+require (
+	github.com/fatih/color v1.13.0
+)
+
+replace (
+	github.com/dummy/package_one => /tmp/dummy_one
+	github.com/dummy/package_two => /tmp/dummy_two
+)
+`
+)
+
+var associated = map[string][]byte{
+	"dummy_one_relative":      []byte(replaceGoModOneRelative),
+	"dummy_one_absolute":      []byte(replaceGoModOneAbsolute),
+	"dummy_multiple_relative": []byte(replaceGoModMultipleRelative),
+	"dummy_multiple_absolute": []byte(replaceGoModMultipleAbsolute),
+}
+
+func Test_Builder_getDepsReplace(t *testing.T) {
+	b := NewBuilder("/tmp", []*common.ModulesInfo{}, "", zap.NewNop(), []string{})
+
+	b.modules = []*common.ModulesInfo{
+		{
+			Version:    "master",
+			ModuleName: "dummy_one_relative",
+			Replace:    "/tmp/dummy_one_relative",
+		},
+		{
+			Version:    "master",
+			ModuleName: "dummy_one_absolute",
+			Replace:    "/tmp/dummy_one_absolute",
+		},
+		{
+			Version:    "master",
+			ModuleName: "dummy_multiple_relative",
+			Replace:    "/tmp/dummy_multiple_relative",
+		},
+		{
+			Version:    "master",
+			ModuleName: "dummy_multiple_absolute",
+			Replace:    "/tmp/dummy_multiple_absolute",
+		},
+	}
+
+	for _, v := range b.modules {
+		_ = os.Mkdir(v.Replace, 0777)
+		_ = os.WriteFile(path.Join(v.Replace, goModStr), associated[v.ModuleName], 0777)
+	}
+
+	defer func() {
+		for _, v := range b.modules {
+			_ = os.RemoveAll(v.Replace)
+		}
+	}()
+
+	toReplace := b.getDepsReplace("/tmp/dummy_multiple_absolute")
+	if len(toReplace) != 2 {
+		t.Error("/tmp/dummy_multiple_absolute must have 2 elements to replace")
+	}
+	if toReplace[0].Module != "github.com/dummy/package_one" || toReplace[0].Replace != "/tmp/dummy_one" {
+		t.Error("The first module to replace must be github.com/dummy/package_one with the replacer /tmp/dummy_one")
+	}
+	if toReplace[1].Module != "github.com/dummy/package_two" || toReplace[1].Replace != "/tmp/dummy_two" {
+		t.Error("The first module to replace must be github.com/dummy/package_two with the replacer /tmp/dummy_two")
+	}
+
+	toReplace = b.getDepsReplace("/tmp/dummy_multiple_relative")
+	if len(toReplace) != 2 {
+		t.Error("/tmp/dummy_multiple_relative must have 2 elements to replace")
+	}
+	if toReplace[0].Module != "github.com/dummy/package" || toReplace[0].Replace != "/tmp/dummy_multiple_relative/something" {
+		t.Error("The first module to replace must be github.com/dummy/package with the replacer /tmp/dummy_multiple_relative/something")
+	}
+	if toReplace[1].Module != "github.com/dummy/another" || toReplace[1].Replace != "/another" {
+		t.Error("The first module to replace must be github.com/dummy/another with the replacer /another")
+	}
+
+	toReplace = b.getDepsReplace("/tmp/dummy_one_absolute")
+	if len(toReplace) != 1 {
+		t.Error("/tmp/dummy_one_absolute must have 1 element to replace")
+	}
+	if toReplace[0].Module != "github.com/dummy/package" || toReplace[0].Replace != "/tmp/dummy" {
+		t.Error("The module to replace must be github.com/dummy/package with the replacer /tmp/dummy")
+	}
+
+	toReplace = b.getDepsReplace("/tmp/dummy_one_relative")
+	if len(toReplace) != 1 {
+		t.Error("/tmp/dummy_one_relative must have 1 element to replace")
+	}
+	if toReplace[0].Module != "github.com/dummy/package" || toReplace[0].Replace != "/tmp/dummy_one_relative/something" {
+		t.Error("The module to replace must be github.com/dummy/package with the replacer /tmp/dummy_one_relative/something")
+	}
+}

--- a/builder/template.go
+++ b/builder/template.go
@@ -21,7 +21,8 @@ require (
 )
 
 replace (
-{{range $v := .Entries}}{{if (ne $v.Replace "")}}{{$v.Module}} => {{$v.Replace}}{{end}}{{end}}
+	{{range $v := .Entries}}{{if (ne $v.Replace "")}}{{$v.Module}} => {{$v.Replace}}
+	{{end}}{{end}}
 )
 `
 


### PR DESCRIPTION
# Reason for This PR

Closes #39

## Description of Changes

Implements a way to handle plugins replace directives in go.mod. With that if a plugin tries to rewrite a dependency, it will be taken in consideration.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
