### PR TITLE
feat[configuration]: support folder directive

### DIFF
--- a/config.go
+++ b/config.go
@@ -48,6 +48,7 @@ type PluginConfig struct {
 	Ref     string `mapstructure:"ref"`
 	Owner   string `mapstructure:"owner"`
 	Repo    string `mapstructure:"repository"`
+	Folder  string `mapstructure:"folder"`
 	Replace string `mapstructure:"replace"`
 }
 

--- a/github/repo.go
+++ b/github/repo.go
@@ -201,13 +201,13 @@ func (r *GHRepo) GetPluginsModData() ([]*common.ModulesInfo, error) {
 
 	for k, v := range r.config.GitHub.Plugins {
 		modInfo := new(common.ModulesInfo)
-		r.log.Debug("[FETCHING PLUGIN DATA]", zap.String("repository", v.Repo), zap.String("owner", v.Owner), zap.String("plugin", k), zap.String("ref", v.Ref))
+		r.log.Debug("[FETCHING PLUGIN DATA]", zap.String("repository", v.Repo), zap.String("owner", v.Owner), zap.String("folder", v.Folder), zap.String("plugin", k), zap.String("ref", v.Ref))
 
 		if v.Ref == "" {
 			return nil, errors.New("ref can't be empty")
 		}
 
-		rc, resp, err := r.client.Repositories.DownloadContents(context.Background(), v.Owner, v.Repo, "go.mod", &github.RepositoryContentGetOptions{Ref: v.Ref})
+		rc, resp, err := r.client.Repositories.DownloadContents(context.Background(), v.Owner, v.Repo, path.Join(v.Folder, "go.mod"), &github.RepositoryContentGetOptions{Ref: v.Ref})
 		if err != nil {
 			return nil, err
 		}

--- a/gitlab/repo.go
+++ b/gitlab/repo.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path"
 	"strings"
 	"time"
 

--- a/gitlab/repo.go
+++ b/gitlab/repo.go
@@ -43,13 +43,13 @@ func (r *GLRepo) GetPluginsModData() ([]*common.ModulesInfo, error) {
 
 	for k, v := range r.config.GitLab.Plugins {
 		modInfo := new(common.ModulesInfo)
-		r.log.Debug("[FETCHING PLUGIN DATA]", zap.String("repository", v.Repo), zap.String("owner", v.Owner), zap.String("plugin", k), zap.String("ref", v.Ref))
+		r.log.Debug("[FETCHING PLUGIN DATA]", zap.String("repository", v.Repo), zap.String("owner", v.Owner), zap.String("folder", v.Folder), zap.String("plugin", k), zap.String("ref", v.Ref))
 
 		if v.Ref == "" {
 			return nil, errors.New("ref can't be empty")
 		}
 
-		file, resp, err := r.client.RepositoryFiles.GetFile(v.Repo, "go.mod", &gitlab.GetFileOptions{
+		file, resp, err := r.client.RepositoryFiles.GetFile(v.Repo, path.Join(v.Folder, "go.mod"), &gitlab.GetFileOptions{
 			Ref: toPtr(v.Ref),
 		})
 		if err != nil {


### PR DESCRIPTION
# Reason for This PR
This PR is related to the discussion https://github.com/spiral/roadrunner-docs/pull/111.
We need to set a property `folder` to support plugins inside a specific repository folder. With that the plugins are not required at the project root folder.

## Description of Changes
 - Add the `Folder` property to the `PluginConfig` structure
 - Update the debug messages to include the `Folder` property value
 - Use a `path.Join` to collapse the `go.mod` and the `Folder` value

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
