### PR TITLE
chore: hygiene pass — fix CLI temp leak, modernize to Go 1.26, drop dead code

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -301,7 +302,7 @@ func (b *Builder) cleanupOutputDir() {
 // GOPROXY, GOPRIVATE, GOFLAGS, etc. are preserved) and overlaying our
 // target-platform / cgo / GOPATH settings.
 func (b *Builder) env() []string {
-	env := append([]string(nil), os.Environ()...)
+	env := slices.Clone(os.Environ())
 	if b.goos != "" {
 		env = setKV(env, "GOOS", b.goos)
 	}

--- a/builder/gomod.go
+++ b/builder/gomod.go
@@ -3,7 +3,6 @@ package builder
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -139,11 +138,9 @@ func (b *Builder) goModTidy(ctx context.Context) error {
 }
 
 // applyRequires invokes `go mod edit -require=<module>@<tag>` for each plugin.
-// Batching all requires in one call avoids spawning N subprocesses.
+// Batching all requires in one call avoids spawning N subprocesses. Build's
+// validateInputs already guarantees at least one plugin.
 func (b *Builder) applyRequires(ctx context.Context) error {
-	if len(b.plugins) == 0 {
-		return errors.New("no plugins provided; use WithPlugins to add at least one")
-	}
 	args := make([]string, 0, len(b.plugins))
 	for _, p := range b.plugins {
 		args = append(args, "-require="+p.RequireArg())

--- a/config.go
+++ b/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	Roadrunner map[string]string `mapstructure:"roadrunner"`
 	// Debug toggles debug build flags.
 	Debug *Debug `mapstructure:"debug"`
-	// Log holds level/mode settings for the zap logger.
+	// Log holds level/mode settings for the slog logger.
 	Log map[string]string `mapstructure:"log"`
 	// TargetPlatform overrides GOOS/GOARCH for cross-compilation. Defaults to host.
 	TargetPlatform *TargetPlatform `mapstructure:"target_platform"`

--- a/config.go
+++ b/config.go
@@ -20,9 +20,6 @@ const (
 
 	// V3 is the canonical major version for the current RoadRunner line.
 	V3 = "v3"
-	// V2025 and V2024 remain accepted for the year-based legacy series.
-	V2025 = "v2025"
-	V2024 = "v2024"
 )
 
 type Config struct {

--- a/config_test.go
+++ b/config_test.go
@@ -1,7 +1,6 @@
 package velox
 
 import (
-	"os"
 	"runtime"
 	"testing"
 
@@ -12,7 +11,7 @@ import (
 func TestExpandEnvs(t *testing.T) {
 	token := "foobarbaz"
 
-	require.NoError(t, os.Setenv("TOKEN", token))
+	t.Setenv("TOKEN", token)
 	c := &Config{
 		Roadrunner: map[string]string{ref: "v2025.1.0"},
 		Debug: &Debug{

--- a/github/cache.go
+++ b/github/cache.go
@@ -1,6 +1,8 @@
 package github
 
 import (
+	"bytes"
+
 	lru "github.com/hashicorp/golang-lru/v2"
 )
 
@@ -28,11 +30,11 @@ func (c *lruCache) Get(key string) ([]byte, bool) {
 	if !ok {
 		return nil, false
 	}
-	return append([]byte(nil), v...), true
+	return bytes.Clone(v), true
 }
 
 // Add stores a copy of value so a subsequent caller-side mutation can't
 // silently corrupt the cached archive.
 func (c *lruCache) Add(key string, value []byte) {
-	c.inner.Add(key, append([]byte(nil), value...))
+	c.inner.Add(key, bytes.Clone(value))
 }

--- a/github/github.go
+++ b/github/github.go
@@ -205,6 +205,8 @@ func (c *Client) saveRR(zipBytes []byte, rrRef, downloadDir string) (string, err
 	if err != nil {
 		return "", err
 	}
+	// GitHub (and GHE) archives always list the single "<repo>-<ref>/" root
+	// directory as the first entry, so File[0].Name is the extracted root.
 	outDir := rc.File[0].Name
 
 	for _, zf := range rc.File {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	connectrpc.com/grpcreflect v1.3.0
 	connectrpc.com/validate v0.6.0
 	github.com/fatih/color v1.19.0
-	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,6 @@ go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/exp v0.0.0-20260527015227-08cc5374adb3 h1:VHEvKbpgPXcPXn40t9cDTGK3JZwMikIEyF/CTrFfu7k=
-golang.org/x/exp v0.0.0-20260527015227-08cc5374adb3/go.mod h1:d2fgXJLVs4dYDHUk5lwMIfzRzSrWCfGZb0ZqeLa/Vcw=
 golang.org/x/exp v0.0.0-20260528192818-c5e92fe887ed h1:1ZL6jkxQHJ7FAYMll9WSawGixViEXwdVjpqaWidDySQ=
 golang.org/x/exp v0.0.0-20260528192818-c5e92fe887ed/go.mod h1:d2fgXJLVs4dYDHUk5lwMIfzRzSrWCfGZb0ZqeLa/Vcw=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=

--- a/internal/cli/build/build.go
+++ b/internal/cli/build/build.go
@@ -5,6 +5,7 @@ package build
 import (
 	"log/slog"
 	"os"
+	"path/filepath"
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
@@ -56,7 +57,15 @@ func BindCommand(cfg *velox.Config, out *string, rootLog *slog.Logger) *cobra.Co
 
 			ctx := cmd.Context()
 			gh := github.NewClient(baseURL, token, github.NewLRUCache(0), log.With("component", "github"))
-			rrPath, err := gh.DownloadTemplate(ctx, os.TempDir(), uuid.NewString(), cfg.Roadrunner[refKey])
+
+			// Download into a unique per-build temp dir and remove it once the
+			// build finishes. The builder's own cleanup only sweeps the output
+			// dir, which differs from this download dir in CLI mode — without
+			// this defer the RR source tree + zip would leak into TempDir.
+			dlDir := filepath.Join(os.TempDir(), uuid.NewString())
+			defer func() { _ = os.RemoveAll(dlDir) }()
+
+			rrPath, err := gh.DownloadTemplate(ctx, dlDir, "", cfg.Roadrunner[refKey])
 			if err != nil {
 				log.Error("downloading template", "error", err)
 				return err

--- a/internal/cli/build/build.go
+++ b/internal/cli/build/build.go
@@ -5,9 +5,7 @@ package build
 import (
 	"log/slog"
 	"os"
-	"path/filepath"
 
-	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	"github.com/roadrunner-server/velox/v3"
@@ -62,7 +60,10 @@ func BindCommand(cfg *velox.Config, out *string, rootLog *slog.Logger) *cobra.Co
 			// build finishes. The builder's own cleanup only sweeps the output
 			// dir, which differs from this download dir in CLI mode — without
 			// this defer the RR source tree + zip would leak into TempDir.
-			dlDir := filepath.Join(os.TempDir(), uuid.NewString())
+			dlDir, err := os.MkdirTemp("", "velox-build-*")
+			if err != nil {
+				return err
+			}
 			defer func() { _ = os.RemoveAll(dlDir) }()
 
 			rrPath, err := gh.DownloadTemplate(ctx, dlDir, "", cfg.Roadrunner[refKey])

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -3,6 +3,7 @@
 package server
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"hash/fnv"
@@ -10,7 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -164,29 +165,31 @@ func (b *BuildServer) generateCacheHash(req *requestV1.BuildRequest) (string, er
 }
 
 func sortedPlugins(in []*requestV1.Plugin) []*requestV1.Plugin {
-	out := append([]*requestV1.Plugin(nil), in...)
-	sort.SliceStable(out, func(i, j int) bool {
-		if out[i].GetModuleName() != out[j].GetModuleName() {
-			return out[i].GetModuleName() < out[j].GetModuleName()
-		}
-		return out[i].GetTag() < out[j].GetTag()
+	out := slices.Clone(in)
+	slices.SortStableFunc(out, func(a, b *requestV1.Plugin) int {
+		return cmp.Or(
+			cmp.Compare(a.GetModuleName(), b.GetModuleName()),
+			cmp.Compare(a.GetTag(), b.GetTag()),
+		)
 	})
 	return out
 }
 
 func sortedReplaces(in []*requestV1.Replace) []*requestV1.Replace {
-	out := append([]*requestV1.Replace(nil), in...)
-	sort.SliceStable(out, func(i, j int) bool { return out[i].GetOld() < out[j].GetOld() })
+	out := slices.Clone(in)
+	slices.SortStableFunc(out, func(a, b *requestV1.Replace) int {
+		return cmp.Compare(a.GetOld(), b.GetOld())
+	})
 	return out
 }
 
 func sortedExcludes(in []*requestV1.Exclude) []*requestV1.Exclude {
-	out := append([]*requestV1.Exclude(nil), in...)
-	sort.SliceStable(out, func(i, j int) bool {
-		if out[i].GetModule() != out[j].GetModule() {
-			return out[i].GetModule() < out[j].GetModule()
-		}
-		return out[i].GetVersion() < out[j].GetVersion()
+	out := slices.Clone(in)
+	slices.SortStableFunc(out, func(a, b *requestV1.Exclude) int {
+		return cmp.Or(
+			cmp.Compare(a.GetModule(), b.GetModule()),
+			cmp.Compare(a.GetVersion(), b.GetVersion()),
+		)
 	})
 	return out
 }

--- a/internal/cli/server/server_test.go
+++ b/internal/cli/server/server_test.go
@@ -1,0 +1,95 @@
+package server
+
+import (
+	"testing"
+
+	requestV1 "github.com/roadrunner-server/velox/v3/gen/go/api/request/v1"
+)
+
+// hashOf computes the cache key for req. generateCacheHash does not touch any
+// BuildServer state, so a zero-value server is sufficient.
+func hashOf(t *testing.T, req *requestV1.BuildRequest) string {
+	t.Helper()
+	h, err := (&BuildServer{}).generateCacheHash(req)
+	if err != nil {
+		t.Fatalf("generateCacheHash: %v", err)
+	}
+	return h
+}
+
+// sampleRequest returns a representative request with multiple plugins,
+// replaces, and excludes so the sorting helpers have something to reorder.
+func sampleRequest() *requestV1.BuildRequest {
+	return &requestV1.BuildRequest{
+		RequestId:      "req-1",
+		RrVersion:      "v2025.1.0",
+		TargetPlatform: &requestV1.Platform{Os: "linux", Arch: "amd64"},
+		Plugins: []*requestV1.Plugin{
+			{ModuleName: "github.com/roadrunner-server/http/v6", Tag: "v6.1.0"},
+			{ModuleName: "github.com/roadrunner-server/logger/v6", Tag: "v6.1.0"},
+			{ModuleName: "github.com/roadrunner-server/rpc/v6", Tag: "v6.0.0"},
+		},
+		Replaces: []*requestV1.Replace{
+			{Old: "github.com/foo/bar", New: "../bar"},
+			{Old: "github.com/baz/qux", New: "../qux"},
+		},
+		Excludes: []*requestV1.Exclude{
+			{Module: "github.com/redis/go-redis/v9", Version: "v9.15.0"},
+			{Module: "github.com/aaa/bbb", Version: "v1.0.0"},
+		},
+		Race:  false,
+		Debug: false,
+	}
+}
+
+func TestGenerateCacheHash_OrderIndependent(t *testing.T) {
+	a := sampleRequest()
+
+	// b is semantically identical but with every repeated list reversed.
+	b := sampleRequest()
+	b.Plugins = []*requestV1.Plugin{b.Plugins[2], b.Plugins[1], b.Plugins[0]}
+	b.Replaces = []*requestV1.Replace{b.Replaces[1], b.Replaces[0]}
+	b.Excludes = []*requestV1.Exclude{b.Excludes[1], b.Excludes[0]}
+
+	if hashOf(t, a) != hashOf(t, b) {
+		t.Fatalf("reordered-but-equal requests produced different hashes:\n a=%s\n b=%s",
+			hashOf(t, a), hashOf(t, b))
+	}
+}
+
+func TestGenerateCacheHash_IgnoresRequestId(t *testing.T) {
+	a := sampleRequest()
+	b := sampleRequest()
+	b.RequestId = "a-completely-different-request-id"
+
+	if hashOf(t, a) != hashOf(t, b) {
+		t.Fatalf("RequestId must not affect the cache hash, but hashes differ:\n a=%s\n b=%s",
+			hashOf(t, a), hashOf(t, b))
+	}
+}
+
+func TestGenerateCacheHash_DistinguishesRealFields(t *testing.T) {
+	base := hashOf(t, sampleRequest())
+
+	cases := map[string]func(*requestV1.BuildRequest){
+		"race":        func(r *requestV1.BuildRequest) { r.Race = true },
+		"debug":       func(r *requestV1.BuildRequest) { r.Debug = true },
+		"rr_version":  func(r *requestV1.BuildRequest) { r.RrVersion = "v3.0.0" },
+		"platform_os": func(r *requestV1.BuildRequest) { r.TargetPlatform.Os = "darwin" },
+		"plugin_tag":  func(r *requestV1.BuildRequest) { r.Plugins[0].Tag = "v6.9.9" },
+		"added_exclude": func(r *requestV1.BuildRequest) {
+			r.Excludes = append(r.Excludes, &requestV1.Exclude{Module: "github.com/x/y", Version: "v1.2.3"})
+		},
+		"replace_new_path": func(r *requestV1.BuildRequest) { r.Replaces[0].New = "../somewhere-else" },
+	}
+
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := sampleRequest()
+			mutate(req)
+			if got := hashOf(t, req); got == base {
+				t.Fatalf("changing %s must change the hash, but it stayed %s", name, base)
+			}
+		})
+	}
+}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -3,9 +3,10 @@
 package plugin
 
 import (
+	"cmp"
 	"crypto/sha256"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -36,11 +37,6 @@ func (p *Plugin) Prefix() string     { return p.prefix }
 func (p *Plugin) ModuleName() string { return p.moduleName }
 func (p *Plugin) Tag() string        { return p.tag }
 
-// Require returns "moduleName tag" — the form historically embedded in go.mod
-// template require() blocks. With the v3 go-mod-edit driven flow, the value is
-// instead passed as `go mod edit -require=moduleName@tag`; see RequireArg.
-func (p *Plugin) Require() string { return fmt.Sprintf("%s %s", p.moduleName, p.tag) }
-
 // RequireArg returns "moduleName@tag" suitable for `go mod edit -require=...`.
 func (p *Plugin) RequireArg() string { return p.moduleName + "@" + p.tag }
 
@@ -66,13 +62,9 @@ func (p *Plugin) Code() string { return p.prefix + ".Plugin{}" }
 func ResolvePrefixCollisions(plugins []*Plugin) {
 	const maxSalt = 1 << 16
 
-	ordered := make([]*Plugin, len(plugins))
-	copy(ordered, plugins)
-	sort.SliceStable(ordered, func(i, j int) bool {
-		if ordered[i].moduleName != ordered[j].moduleName {
-			return ordered[i].moduleName < ordered[j].moduleName
-		}
-		return ordered[i].tag < ordered[j].tag
+	ordered := slices.Clone(plugins)
+	slices.SortStableFunc(ordered, func(a, b *Plugin) int {
+		return cmp.Or(cmp.Compare(a.moduleName, b.moduleName), cmp.Compare(a.tag, b.tag))
 	})
 
 	seen := make(map[string]struct{}, len(ordered))

--- a/velox.toml
+++ b/velox.toml
@@ -8,9 +8,11 @@ enabled = false
 level = "debug"
 mode = "production"
 
-[target_platform]
-os = "darwin"
-arch = "arm64"
+# [target_platform] is optional and defaults to the host GOOS/GOARCH.
+# Uncomment and set os/arch to cross-compile (e.g. os = "linux", arch = "amd64").
+# [target_platform]
+# os = "linux"
+# arch = "amd64"
 
 [github]
 # base_url is optional. Set it to a GitHub Enterprise host (e.g. "https://ghe.example.com") to


### PR DESCRIPTION
## Summary

A focused hygiene pass over the v3 codebase. `go vet` and `golangci-lint` were already clean, so every change here comes from manual review. No build-pipeline behavior changes beyond the temp-dir cleanup fix.

## Bug fix
- **CLI temp-dir leak.** `vx build` downloads the RoadRunner source into `TempDir/<uuid>`, but the builder's cleanup only sweeps the *output* dir. Those paths coincide in server mode (`TempDir/hash`) but not in CLI mode (`-o` target), so every `vx build` orphaned a full RR source tree + zip in `TempDir`. Now the CLI downloads into a dedicated per-build dir and removes it via `defer`.

## Modern Go (1.26)
- `sort.SliceStable` → `slices.SortStableFunc` + `cmp.Or`/`cmp.Compare` (plugin prefix resolver, three server cache-key sorters).
- Hand-rolled `append([]T(nil), …)` clones → `slices.Clone` / `bytes.Clone` (builder env, github archive cache).
- `os.Setenv` → `t.Setenv` in `TestExpandEnvs` (was leaking the env var across tests).

## Dead code / simplification
- Remove unused `Plugin.Require()` (superseded by `RequireArg`).
- Remove unused exported `velox.V2025` / `velox.V2024` constants — the year-based major is derived dynamically in `parseRRMajor`.
- Drop the redundant empty-plugins guard in `applyRequires` (`Build`'s `validateInputs` already enforces it).
- Document the GitHub-archive root-dir assumption in `saveRR`.

## Verification
- `go build ./...`, `go vet ./...` — clean.
- `go test -race ./...` — all packages green.
- `golangci-lint run ./...` — 0 issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed deprecated version constants `V2024` and `V2025`; use `V3` only.
  * Removed `Plugin.Require()` method; use `RequireArg()` instead.

* **Bug Fixes**
  * Improved cleanup of temporary files generated during the build process.

* **Refactoring**
  * Modernized internal code to use Go's standard library helpers for sorting and cloning operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roadrunner-server/velox/pull/328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->